### PR TITLE
chore: Add create log artifacts when e2e test fails

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -540,6 +540,20 @@ check_e2e_labels:
         INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
   {!{- tmpl.Exec "e2e_run_template" (slice .provider "run-test" (coll.Has $ctx "manualRun") ) | strings.Indent 6 }!}
 
+################################################### Collect logs when e2e failed ###########################
+    {!{- if coll.Has $ctx "manualRun" }!}
+    - name: "Creating log artifacts when e2e testing fails"
+      id: create_e2e_tests_logs
+      if: failure() || cancelled()
+      env:
+        SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+        SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+      run: |
+        echo $SSH_CONNECT_STR_FILE
+        echo $SSH_BASTION_STR_FILE
+    {!{- end }!}      
+################################################### Collect logs when e2e failed ###########################
+
 {!{- if coll.Has $ctx "manualRun" }!}
     - name: Read connection string
       if: ${{ failure() || cancelled() }}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -529,6 +529,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1024,6 +1037,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1519,6 +1545,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2014,6 +2053,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2509,6 +2561,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3004,6 +3069,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3499,6 +3577,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -533,6 +533,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1036,6 +1049,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1539,6 +1565,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2042,6 +2081,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2545,6 +2597,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3048,6 +3113,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3551,6 +3629,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -422,6 +422,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -930,6 +934,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -1395,6 +1403,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -1859,6 +1871,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -2320,6 +2336,10 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
 
       - name: Cleanup bootstrapped cluster
         if: always()
@@ -2783,6 +2803,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -3242,6 +3266,10 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
 
       - name: Cleanup bootstrapped cluster
         if: always()
@@ -3711,6 +3739,10 @@ jobs:
 
         # </template: e2e_run_template>
 
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Cleanup bootstrapped cluster
         if: always()
         id: cleanup_cluster
@@ -4176,6 +4208,10 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+
+  ################################################### Collect logs when e2e failed ###########################
 
       - name: Cleanup bootstrapped cluster
         if: always()

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -575,6 +575,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1115,6 +1128,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1655,6 +1681,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2195,6 +2234,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2735,6 +2787,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3275,6 +3340,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3815,6 +3893,19 @@ jobs:
           /deckhouse/testing/cloud_layouts/script_eks.sh wait_cluster_ready"
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -527,6 +527,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1018,6 +1031,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1509,6 +1535,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2000,6 +2039,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2491,6 +2543,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2982,6 +3047,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3473,6 +3551,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -527,6 +527,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1018,6 +1031,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1509,6 +1535,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2000,6 +2039,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2491,6 +2543,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2982,6 +3047,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3473,6 +3551,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -527,6 +527,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1018,6 +1031,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1509,6 +1535,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2000,6 +2039,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2491,6 +2543,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2982,6 +3047,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3473,6 +3551,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -535,6 +535,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1042,6 +1055,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1549,6 +1575,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2056,6 +2095,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2563,6 +2615,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3070,6 +3135,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3577,6 +3655,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -529,6 +529,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1024,6 +1037,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1519,6 +1545,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2014,6 +2053,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2509,6 +2561,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3004,6 +3069,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3499,6 +3577,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -531,6 +531,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+  ################################################### Collect logs when e2e failed ###########################
+
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1030,6 +1043,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -1529,6 +1555,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2028,6 +2067,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -2527,6 +2579,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3026,6 +3091,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster
@@ -3525,6 +3603,19 @@ jobs:
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
 
         # </template: e2e_run_template>
+
+  ################################################### Collect logs when e2e failed ###########################
+      - name: "Creating log artifacts when e2e testing fails"
+        id: create_e2e_tests_logs
+        if: failure() || cancelled()
+        env:
+          SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
+        run: |
+          echo $SSH_CONNECT_STR_FILE
+          echo $SSH_BASTION_STR_FILE
+
+  ################################################### Collect logs when e2e failed ###########################
       - name: Read connection string
         if: ${{ failure() || cancelled() }}
         id: check_stay_failed_cluster


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Restrict user access by email in DexClient and DexAuthenticator
---
section: documentation, upmeter, prometheus, cilium-hubble, deckhouse-tools, openvpn, dashboard, istio
type: feature
summary: Add auth.allowedUserEmails option to restrict access to the application based on user email.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
